### PR TITLE
Fix a TypeError when there is no events

### DIFF
--- a/lib/groonga/response/select.js
+++ b/lib/groonga/response/select.js
@@ -10,6 +10,14 @@ util.inherits(SelectResponse, BaseResponse);
 
 function parseSelectResult(result) {
   var parsedResult = {
+    count: 0,
+    columns: {},
+    records: []
+  };
+  if (!result) {
+    return parsedResult;
+  }
+  parsedResult = {
     count:   result[0][0],
     columns: new Columns(result[1])
   };


### PR DESCRIPTION
  TypeError: Cannot read property '0' of undefined
      at parseSelectResult (/home/kenhys/work/sharetary/sharetary.work/lib/groonga/response/select.js:13:20)
      at SelectResponse.Object.defineProperty.get (/home/kenhys/work/sharetary/sharetary.work/lib/groonga/response/select.js:26:25)
      at Object.<anonymous> (/home/kenhys/work/sharetary/sharetary.work/lib/groonga/client.js:93:26)
      at _fulfilled (/home/kenhys/work/sharetary/sharetary.work/node_modules/q/q.js:834:54)
      at self.promiseDispatch.done (/home/kenhys/work/sharetary/sharetary.work/node_modules/q/q.js:863:30)
      at Promise.promise.promiseDispatch (/home/kenhys/work/sharetary/sharetary.work/node_modules/q/q.js:796:13)
      at /home/kenhys/work/sharetary/sharetary.work/node_modules/q/q.js:604:44
      at runSingle (/home/kenhys/work/sharetary/sharetary.work/node_modules/q/q.js:137:13)
      at flush (/home/kenhys/work/sharetary/sharetary.work/node_modules/q/q.js:125:13)
      at process._tickCallback (node.js:355:11)
  # Please enter the commit message for your changes. Lines starting
