### PR TITLE
Groongaが起動していないときにエラーメッセージを表示するようにした

### DIFF
--- a/lib/groonga/client.js
+++ b/lib/groonga/client.js
@@ -30,6 +30,12 @@ function shrinkParams(params) {
 function Client(options) {
   this.base = options.base;
   this.ensureBaseIsGroongaEndpoint();
+  var groongaUrl = this.base;
+  http.get(groongaUrl, function(response) {
+    console.log('Groonga is running at ' + groongaUrl);
+  }).on('error', function(event) {
+    console.log('Groonga is NOT running');
+  });
 }
 
 Client.prototype = {


### PR DESCRIPTION
Groongaのデーモンが起動していない時にでもエラーメッセージが出ないので、そのミスに気づきにくいと感じました。

なので、起動時にGroongaに接続を試みて、成功した場合は以下のメッセージを出力し、

> Groonga is running at ' + this.base

失敗した場合には以下のようなエラーを出力するようにしてみました

> Groonga is NOT running
